### PR TITLE
Fix switch case indent after function call with dictionary

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1517,9 +1517,7 @@ void indent_text()
                      && (  (  next->Is(CT_BRACE_CLOSE)
                            && next->GetParentType() == CT_OC_AT)
                         || (  next->Is(CT_SQUARE_CLOSE)
-                           && next->GetParentType() == CT_OC_AT)
-                        || (  next->Is(CT_SQUARE_CLOSE)
-                           && next->GetParentType() == CT_OC_MSG)))
+                           && next->GetParentType() == CT_OC_AT)))
                {
                   count++;
                   next = next->GetNextNc();

--- a/tests/config/oc/3812.cfg
+++ b/tests/config/oc/3812.cfg
@@ -1,0 +1,3 @@
+indent_switch_case = 2
+indent_with_tabs = 0
+indent_columns = 2

--- a/tests/expected/oc/50912-3812.m
+++ b/tests/expected/oc/50912-3812.m
@@ -1,0 +1,8 @@
+- (int)test
+{
+  [obj method:[obj2 method2:@{}]];
+  switch (var) {
+    case one: return 3;
+  }
+  return 0;
+}

--- a/tests/input/oc/3812.m
+++ b/tests/input/oc/3812.m
@@ -1,0 +1,8 @@
+- (int)test
+{
+  [obj method:[obj2 method2:@{}]];
+  switch (var) {
+    case one: return 3;
+  }
+  return 0;
+}

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -179,6 +179,7 @@
 50909  oc/3766.cfg                              oc/3766.m
 50910  oc/3767.cfg                              oc/3767.mm                          OC+
 50911  oc/3811.cfg                              oc/3811.mm                          OC+
+50912  oc/3812.cfg                              oc/3812.m
 
 # test the options sp_ with the value "ignore"
 51000  oc/sp_cond_ternary_short.cfg             oc/sp_cond_ternary_short.m


### PR DESCRIPTION
I think the extra square close condition was added by accident in https://github.com/uncrustify/uncrustify/commit/437aac5692470e543ab0c0821480bcc5bf68bad0 

Fixes #3182

input
```
- (int)test
{
  [obj method:[obj2 method2:@{}]];
  switch (var) {
    case one: return 3;
  }
  return 0;
}
```

bad output (expected to be same as input)
```
- (int)test
{
  [obj method:[obj2 method2:@{}]];
  switch (var) {
      case one: return 3;
  }
  return 0;
}
```

config
```
indent_switch_case = 2
indent_with_tabs = 0
indent_columns = 2
```

command
```
./uncrustify -l OC+ -c tmp.cfg -f test_file_original.m -o test_file_original_unc.m -p myExample.p -L A 2>myExample.A -ds dump
```