### PR TITLE
Add new option to configure lambda indent in parameter

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -3067,6 +3067,12 @@ static void handle_oc_block_literal(Chunk *pc)
    // mark the braces
    bbo->SetParentType(CT_OC_BLOCK_EXPR);
    bbc->SetParentType(CT_OC_BLOCK_EXPR);
+
+   // mark the OC_BLOCK
+   for (auto *tmp = bbo; tmp != bbc; tmp = tmp->GetNextNcNnl())
+   {
+      tmp->SetFlagBits(PCF_OC_IN_BLOCK);
+   }
 } // handle_oc_block_literal
 
 

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2091,6 +2091,16 @@ void indent_text()
             }
             log_indent();
          }
+         else if (  pc->GetParentType() == CT_CPP_LAMBDA
+                 && pc->Is(CT_BRACE_OPEN)
+                 && frm.prev().pc->orig_line == pc->orig_line
+                 && options::indent_cpp_lambda_to_brace()) {
+            frm.top().indent = frm.prev().indent;
+            frm.top().indent_tab = frm.top().indent;
+
+            // if same line as parent, decrease indent
+            indent_column_set(frm.top().indent - indent_size);
+         }
          else
          {
             // Use the prev indent level + indent_size.

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2040,6 +2040,11 @@ void indent_text()
                log_indent();
                indent_column_set(frm.prev().pc->column);
             }
+            // Issue #3183
+            else if (pc->TestFlags(PCF_OC_IN_BLOCK) && pc->GetParentType() == CT_SWITCH)
+            {
+               frm.top().indent = frm.prev().indent_tmp;
+            }
             else
             {
                // We are inside ({ ... }) -- indent one tab from the paren

--- a/src/options.h
+++ b/src/options.h
@@ -1833,6 +1833,11 @@ indent_token_after_brace; // = true
 extern Option<bool>
 indent_cpp_lambda_body;
 
+// Whether or not to use the opening brace when formatting cpp lambdas in
+// function parameters, ignoring the opening parenthesis of the function.
+extern Option<bool>
+indent_cpp_lambda_to_brace;
+
 // How to indent compound literals that are being returned.
 // true: add both the indent from return & the compound literal open brace
 //       (i.e. 2 indent levels)

--- a/src/pcf_flags.h
+++ b/src/pcf_flags.h
@@ -83,6 +83,7 @@ enum E_PcfFlag : decltype ( 0ULL )
    PCF_NOT_POSSIBLE    = pcf_bit(47),  //! it is not possible to make an one_liner
                                        //! because the line would be too long
    PCF_IN_CONDITIONAL  = pcf_bit(48),  //! inside a conditional ternary expression
+   PCF_OC_IN_BLOCK     = pcf_bit(49),  //! inside OC block function
 };
 
 UNC_DECLARE_FLAGS(T_PcfFlags, E_PcfFlag);

--- a/tests/config/oc/3813.cfg
+++ b/tests/config/oc/3813.cfg
@@ -1,0 +1,3 @@
+indent_switch_case = 2
+indent_with_tabs = 0
+indent_columns = 2

--- a/tests/expected/oc/50913-3813.m
+++ b/tests/expected/oc/50913-3813.m
@@ -1,0 +1,20 @@
+- (void)func {
+  func2(^{
+    switch (type) {
+      case one:
+        break;
+      default:
+        break;
+    }
+  });
+}
+
+- (void)func {
+  func2(^{
+    if(YES) {
+      switch (type) {
+        case one: break;
+      }
+    }
+  });
+}

--- a/tests/input/oc/3813.m
+++ b/tests/input/oc/3813.m
@@ -1,0 +1,20 @@
+- (void)func {
+  func2(^{
+    switch (type) {
+      case one:
+        break;
+      default:
+        break;
+    }
+  });
+}
+
+- (void)func {
+  func2(^{
+    if(YES) {
+      switch (type) {
+        case one: break;
+      }
+    }
+  });
+}

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -180,6 +180,7 @@
 50910  oc/3767.cfg                              oc/3767.mm                          OC+
 50911  oc/3811.cfg                              oc/3811.mm                          OC+
 50912  oc/3812.cfg                              oc/3812.m
+50913  oc/3813.cfg                              oc/3813.m
 
 # test the options sp_ with the value "ignore"
 51000  oc/sp_cond_ternary_short.cfg             oc/sp_cond_ternary_short.m


### PR DESCRIPTION
POC for #3815

Take this example

input
```
func(^ {
  return object;
});

func2([]() {
  return object;
});
```

output
```
func(^ {
  return object;
});

func2([]() {
    return object;
  });
```

config
```
indent_columns                  = 2
indent_with_tabs                = 0
indent_paren_open_brace         = true
indent_func_call_param          = true
indent_oc_block                 = true
```

The objc block indents because of `indent_oc_block = true`. Currently there is no such option for cpp lambdas. Would it make sense to add a config param, `indent_cpp_lambda_to_brace`, to mirror the objective-c option? This PR is a demo of the new option.