### PR TITLE
Fix crash when parsing complex OC block

### DIFF
--- a/src/ParseFrame.cpp
+++ b/src/ParseFrame.cpp
@@ -215,6 +215,7 @@ void ParseFrame::pop(const char *func, int line, Chunk *pc)
       || pc->GetType() == CT_FPAREN_CLOSE
       || pc->GetType() == CT_LPAREN_CLOSE
       || pc->GetType() == CT_SPAREN_CLOSE
+      || pc->GetType() == CT_TPAREN_CLOSE
       || pc->GetType() == CT_CLASS_COLON
       || pc->GetType() == CT_ANGLE_CLOSE
       || pc->GetType() == CT_SEMICOLON

--- a/tests/config/oc/3823.cfg
+++ b/tests/config/oc/3823.cfg
@@ -1,0 +1,2 @@
+indent_columns                  = 2
+indent_with_tabs                = 0

--- a/tests/expected/oc/50916-3823.m
+++ b/tests/expected/oc/50916-3823.m
@@ -1,0 +1,6 @@
+void (^(^complexBlock)(void (^)(void)))(void) = ^(void (^aBlock)(void)) {
+  NSLog(@"Good");
+  return ^{
+    NSLog(@"Nice");
+  };
+};

--- a/tests/input/oc/3823.m
+++ b/tests/input/oc/3823.m
@@ -1,0 +1,6 @@
+void (^(^complexBlock)(void (^)(void)))(void) = ^(void (^aBlock)(void)) {
+  NSLog(@"Good");
+  return ^{
+    NSLog(@"Nice");
+  };
+};

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -183,6 +183,7 @@
 50913  oc/3813.cfg                              oc/3813.m
 50914  oc/3819.cfg                              oc/3819.m
 50915  common/empty.cfg                         oc/3822.h
+50916  oc/3823.cfg                        oc/3823.m
 
 # test the options sp_ with the value "ignore"
 51000  oc/sp_cond_ternary_short.cfg             oc/sp_cond_ternary_short.m


### PR DESCRIPTION
https://github.com/uncrustify/uncrustify/issues/3823