### PR TITLE
Add new option to configure lambda indent in parameter

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2052,6 +2052,16 @@ void indent_text()
             }
             log_indent();
          }
+         else if (  pc->GetParentType() == CT_CPP_LAMBDA
+                 && pc->Is(CT_BRACE_OPEN)
+                 && frm.prev().pc->orig_line == pc->orig_line
+                 && options::indent_cpp_lambda_to_brace()) {
+            frm.top().indent = frm.prev().indent;
+            frm.top().indent_tab = frm.top().indent;
+
+            // if same line as parent, decrease indent
+            indent_column_set(frm.top().indent - indent_size);
+         }
          else
          {
             // Use the prev indent level + indent_size.

--- a/src/options.h
+++ b/src/options.h
@@ -1833,6 +1833,11 @@ indent_token_after_brace; // = true
 extern Option<bool>
 indent_cpp_lambda_body;
 
+// Whether or not to use the opening brace when formatting cpp lambdas in
+// function parameters, ignoring the opening parenthesis of the function.
+extern Option<bool>
+indent_cpp_lambda_to_brace;
+
 // How to indent compound literals that are being returned.
 // true: add both the indent from return & the compound literal open brace
 //       (i.e. 2 indent levels)


### PR DESCRIPTION
POC for #3815

Take this example

input
```
func(^ {
  return object;
});

func2([]() {
  return object;
});
```

output
```
func(^ {
  return object;
});

func2([]() {
    return object;
  });
```

config
```
indent_columns                  = 2
indent_with_tabs                = 0
indent_paren_open_brace         = true
indent_func_call_param          = true
indent_oc_block                 = true
```

The objc block indents because of `indent_oc_block = true`. Currently there is no such option for cpp lambdas. Would it make sense to add a config param, `indent_cpp_lambda_to_brace`, to mirror the objective-c option? This PR is a demo of the new option.